### PR TITLE
When I don't #import UIKit.h in .pch,error!

### DIFF
--- a/JDStatusBarNotification/JDStatusBarStyle.h
+++ b/JDStatusBarNotification/JDStatusBarStyle.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 extern NSString *const JDStatusBarStyleError;   /// This style has a red background with a white Helvetica label.
 extern NSString *const JDStatusBarStyleWarning; /// This style has a yellow background with a gray Helvetica label.


### PR DESCRIPTION
when i use JDStatusBarNotification,find:
JDStatusBarStyle.h lost #import UIKit.h
because i don't add #import UIKit.h in .pch.