### PR TITLE
XCode 7: supportedInterfaceOrientations warning fix.

### DIFF
--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -528,7 +528,7 @@
     return [[self mainController] shouldAutorotate];
 }
 
-- (NSUInteger)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return [[self mainController] supportedInterfaceOrientations];
 }
 


### PR DESCRIPTION
This is a harmless pull request that changes the signature of supportedInterfaceOrientations to return UIInterfaceOrientationMask  because XCode 7 produces a warning if the method signature specify a NSUInteger return type.