### PR TITLE
Fix: ensure dismiss does happen synchronously without 0.0s animation

### DIFF
--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -293,9 +293,6 @@
         // animate out
         [UIView animateWithDuration:0.4 animations:animation completion:complete];
     } else {
-        // if animated is false instantly call functions.
-        // ensure no 0.0s animation is being used, as it can lead to UI glitches
-        // Especially fixes issue with dismissing in viewWillDisappear and scrollView contentInset in the pushed viewcontroller
         animation();
         complete(YES);
     }


### PR DESCRIPTION
Fix for `- (void)dismissAnimated:(BOOL)animated;`

Timing fix when dismissing in viewWillDisappear
* if animated is false instantly call functions.
* ensure no 0.0s animation is being used, as it can lead to UI glitches
* Especially fixes issue with dismissing in viewWillDisappear and scrollView contentInset in the pushed viewcontroller